### PR TITLE
Add names for top-level anonymous struct types

### DIFF
--- a/include/hcdebug.h
+++ b/include/hcdebug.h
@@ -5,7 +5,7 @@
 
 #define HC_API_VERSION 1
 
-typedef struct {
+typedef struct hc_Breakpoint {
     struct {
         char const* description;
         unsigned (*enable)(void* ud, int yes);
@@ -14,7 +14,7 @@ typedef struct {
 }
 hc_Breakpoint;
 
-typedef struct {
+typedef struct hc_Memory {
     struct {
         char const* id;
         char const* description;
@@ -38,7 +38,7 @@ typedef struct {
 }
 hc_Memory;
 
-typedef struct {
+typedef struct hc_Cpu {
     struct {
         /* CPU info */
         char const* description;
@@ -75,7 +75,7 @@ typedef struct {
 }
 hc_Cpu;
 
-typedef struct {
+typedef struct hc_System {
     struct {
         char const* description;
 
@@ -95,7 +95,7 @@ typedef struct {
 }
 hc_System;
 
-typedef struct {
+typedef struct hc_DebuggerIf {
     unsigned const frontend_api_version;
     unsigned core_api_version;
 


### PR DESCRIPTION
This allows forward declarations in other modules and projects.

Currently, it's impossible to declare a function in C like:

```
void somefunc(hc_DebuggerIf*);
```

without first including `hcdebug.h`. This is relevant for me, as I'd like to expose an optional function from a library which takes an `hc_DebuggerIf`, but I don't want to have to require that `hcdebug.h` is included or even in the include path at all. My only current option is to use `void*`, which requires everyone (caller and callee) to do some unfortunate casting.