### PR TITLE
added subscription IDs to hcdebug.h

### DIFF
--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -215,9 +215,11 @@ void hc::Debugger::tick() {
     }
 }
 
-void hc::Debugger::executionBreakpoint(hc_ExecutionBreakpoint const* event) {}
+void hc::Debugger::executionBreakpoint(hc_ExecutionEvent const* event) {}
 
-void hc::Debugger::interruptBreakpoint(hc_InterruptBreakpoint const* event) {}
+void hc::Debugger::returnBreakpoint(hc_ExecutionReturnEvent const* event) {}
+
+void hc::Debugger::interruptBreakpoint(hc_InterruptEvent const* event) {}
 
 void hc::Debugger::memoryWatchpoint(hc_MemoryWatchpoint const* event) {}
 
@@ -231,6 +233,7 @@ void hc::Debugger::handleEvent(void* frontend_user_data, hc_Event const* event) 
     switch (event->type) {
         case HC_EVENT_TICK: static_cast<Debugger*>(frontend_user_data)->tick(); break;
         case HC_EVENT_EXECUTION: static_cast<Debugger*>(frontend_user_data)->executionBreakpoint(&event->event.execution); break;
+        case HC_EVENT_RETURN: static_cast<Debugger*>(frontend_user_data)->returnBreakpoint(&event->event.execution_return); break;
         case HC_EVENT_INTERRUPT: static_cast<Debugger*>(frontend_user_data)->interruptBreakpoint(&event->event.interrupt); break;
         case HC_EVENT_MEMORY: static_cast<Debugger*>(frontend_user_data)->memoryWatchpoint(&event->event.memory); break;
         case HC_EVENT_REG: static_cast<Debugger*>(frontend_user_data)->registerWatchpoint(&event->event.reg); break;

--- a/src/Debugger.h
+++ b/src/Debugger.h
@@ -54,8 +54,9 @@ namespace hc {
 
     protected:
         void tick();
-        void executionBreakpoint(hc_ExecutionBreakpoint const* event);
-        void interruptBreakpoint(hc_InterruptBreakpoint const* event);
+        void executionBreakpoint(hc_ExecutionEvent const* event);
+        void returnBreakpoint(hc_ExecutionReturnEvent const* event);
+        void interruptBreakpoint(hc_InterruptEvent const* event);
         void memoryWatchpoint(hc_MemoryWatchpoint const* event);
         void registerWatchpoint(hc_RegisterWatchpoint const* event);
         void ioWatchpoint(hc_IoWatchpoint const* event);


### PR DESCRIPTION
## What's new

- Adds two new functions to hc_DebuggerIf: `subscribe` and `unsubscribe`
- Subscriptions allow specific events to be reported. If no subscriptions are made, no events will be reported. This is critical for efficiency.
- Each event type has an associated subscribe struct, detailing the specifics. For example, memory watchpoints specify the address range and the operation type(s).
- Execution events are now more specific: they report one of (a) every step; (b) all steps, but skipping interrupts; or (c) all steps, but skipping interrupts and subroutines.
- _Return events_ (i.e. _step out_) are a new event type, since it occurs after an instruction is executed rather than before. (For efficiency reasons, it seems best to invoke the callback immediately after the return instruction rather than immediately before the returned-to instruction on the following step.)
- Changed memory and interrupt access flags from `unsigned` to `uint8_t`, since they seem very unlikely to ever have more than 4 possible values. Perhaps this is not a good idea -- please let me know.

## Discussion

- Does "subscription id" make sense, or should the frontend just give a userdata value that will be included in the event struct when the event is reported by the core? If no subscription ID, how do we expect the core to efficiently cancel specific subscriptions?